### PR TITLE
Feature/デバイス登録時、バリデーションメッセージの修正、その他

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
+gem 'bootstrap-sass', '~> 3.3.6'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,9 +39,14 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
+    autoprefixer-rails (6.5.3.1)
+      execjs
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.2)
     byebug (9.0.6)
     coffee-rails (4.1.1)
@@ -149,6 +154,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt
+  bootstrap-sass (~> 3.3.6)
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,6 @@
 // about supported directives.
 //
 //= require jquery
+//= require bootstrap-sprockets
 //= require jquery_ujs
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
  *= require_tree .
  *= require_self
  */
+ @import "bootstrap-sprockets";
+ @import "bootstrap";

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -14,11 +14,11 @@ class DevicesController < ApplicationController
   def create
     @device = Device.new(device_params)
     if @device.save
-      flash[:success] = "新しいデバイスが登録されました"
       redirect_to devices_path
+      flash[:success] = "新しいデバイスが登録されました"
     else
-      flash.now[:error] = "新しいデバイスを登録できません"
-      render new_device_path
+      # flash.now[:error] = "新しいデバイスを登録できません"
+      render 'new'
     end
   end
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,6 +1,8 @@
 class Device < ApplicationRecord
   belongs_to :user
   validates :preset_temperature, presence: true,
-            numericality: { only_integer: true, greater_than: 20, less_than: 30 }
+            numericality: { only_integer: true, greater_than: 20, less_than: 30, message: "設定温度は20〜30の範囲で入力して下さい" }
   validates :device_name, presence: true
+  validates :preset_temperature, presence: { message: "温度設定を入力して下さい"}
+  validates :device_name, presence: { message: "デバイス名を入力して下さい"}
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,4 +1,6 @@
 class Device < ApplicationRecord
   belongs_to :user
-  validates :preset_temperature, numericality: { only_integer: true, greater_than: 10, less_than: 40 }
+  validates :preset_temperature, presence: true,
+            numericality: { only_integer: true, greater_than: 20, less_than: 30 }
+  validates :device_name, presence: true
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,8 +1,7 @@
 class Device < ApplicationRecord
   belongs_to :user
-  validates :preset_temperature, presence: true,
-            numericality: { only_integer: true, greater_than: 20, less_than: 30, message: "設定温度は20〜30の範囲で入力して下さい" }
-  validates :device_name, presence: true
-  validates :preset_temperature, presence: { message: "温度設定を入力して下さい"}
-  validates :device_name, presence: { message: "デバイス名を入力して下さい"}
+  validates :device_name, presence:  { message: "デバイス名が入力されていません"}
+  validates :preset_temperature, presence: { message: "設定温度が入力されていません。"},
+            numericality: { only_integer: true, greater_than_or_equal_to: 20, less_than_or_equal_to: 30, message: "設定温度は20〜30の範囲で入力して下さい" }
+  validates :device_communication, inclusion: { in: [true, false] }
 end

--- a/app/views/devices/edit.html.erb
+++ b/app/views/devices/edit.html.erb
@@ -2,6 +2,8 @@
 
 <div class="container">
   <%= form_for(@device) do |f| %>
+    <%= render 'shared/error_messages' %>
+
     <div class="form-group">
       <%= f.label :device_name %>
       <%= f.text_field :device_name %>
@@ -15,8 +17,10 @@
       <%= f.number_field :preset_temperature %>
     </div>
     <div class="form-group">
-      <%= f.label :device_communication, 'デバイスとの接続スイッチ のオン/オフ' %>
-      <%= f.text_field :device_communication %>
+      <div class="control-label form-inline">
+        <%= f.check_box :device_communication, {class: :checkbox}, true, false %>
+        <%= f.label :device_communication, 'デバイスとの接続スイッチをオン' %>
+      </div>
     </div>
 
     <%= f.submit "edit device", class: "btn btn-large btn-primary" %>

--- a/app/views/devices/index.html.erb
+++ b/app/views/devices/index.html.erb
@@ -1,13 +1,33 @@
 <h1>Devices#index</h1>
 <div class="container">
 <p>デバイス一覧：</p>
-  <% @device.each do |n| %>
-    <ul>
-      <li><%= n.device_name %></li>
-      <%= link_to '詳細', device_path(n.id) %> <br>
-      <%= link_to '編集', edit_device_path(n.id) %> <br>
-      <%= link_to '削除', device_path(n.id), method: :delete, data: { confirm: "まじで？" } %>
-    </ul>
-  <% end %>
+    <div class="table-responsive">
+    <table class="table">
+        <thead>
+          <tr>
+            <th>デバイス名</th>
+            <th>設定温度</th>
+            <th>デバイスとの接続</th>
+            <th>編集</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @device.each do |n| %>
+          <tr>
+            <td><%= n.device_name %></td>
+            <td><%= n.preset_temperature %></td>
+              <% if n.device_communication %>
+                <td><%= "オン" %></td>
+              <% else %>
+                <td><%= "オフ" %></td>
+              <% end %>
+            <td><%= link_to '詳細', device_path(n.id) %>
+            <%= link_to '編集', edit_device_path(n.id) %>
+            <%= link_to '削除', device_path(n.id), method: :delete, data: { confirm: "まじで？" } %></td>
+          </tr>
+          <% end %>
+        </tbody>
+    </table>
+    </div>
   <%= link_to 'デバイスの新規追加', new_device_path %>
 </div>

--- a/app/views/devices/new.html.erb
+++ b/app/views/devices/new.html.erb
@@ -14,11 +14,12 @@
     </div>
     <div class="form-group">
       <%= f.label :preset_temperature, '設定温度（20〜30の数字で入力すること）' %>
-      <%= f.number_field :preset_temperature, class: 'form-control' %>度
+      <%= f.number_field :preset_temperature, class: 'form-control' %>
     </div>
     <div class="form-group">
       <%= f.label :device_communication, 'デバイスとの接続スイッチ のオン/オフ' %>
-      <%= f.text_field :device_communication, class: 'form-control' %>
+      デバイス接続オン
+      <%= f.check_box :device_communication %>
     </div>
 
     <%= f.submit "Create new device", class: "btn btn-large btn-primary" %>

--- a/app/views/devices/new.html.erb
+++ b/app/views/devices/new.html.erb
@@ -10,19 +10,19 @@
     </div>
     <div class="form-group">
       <%= f.label :mac_address %>
-      <%= f.text_field :mac_address, class: 'form-control' %>
+      <%= f.text_field :mac_address, class: 'form-control', pattern: "\d{1,2}\:\d{1,2}\:\d{1,2}\:\d{1,2}\:\d{1,2}\:\d{1,2}\:", placeholder: "xx:xx:xx:xx:xx:xx" %>
     </div>
     <div class="form-group">
-      <%= f.label :preset_temperature, '設定温度（20〜30の数字で入力すること）' %>
-      <%= f.number_field :preset_temperature, class: 'form-control' %>
+      <%= f.label :preset_temperature, '設定温度' %>
+      <%= f.number_field :preset_temperature, class: 'form-control', placeholder: "20〜30の数字で入力すること"%>
     </div>
     <div class="form-group">
-      <%= f.label :device_communication, 'デバイスとの接続スイッチ のオン/オフ' %>
-      デバイス接続オン
-      <%= f.check_box :device_communication %>
+      <div class="control-label form-inline">
+        <%= f.check_box :device_communication, {}, "true", "false" %>
+        <%= f.label :device_communication, 'デバイスとの接続スイッチをオン' %>
+      </div>
     </div>
 
-    <%= f.submit "Create new device", class: "btn btn-large btn-primary" %>
-
+    <%= f.submit "Create new device", class: "btn btn-large btn-primary", name: nil %>
   <% end %>
 </div>

--- a/app/views/devices/new.html.erb
+++ b/app/views/devices/new.html.erb
@@ -5,21 +5,21 @@
     <%= render 'shared/error_messages' %>
 
     <div class="form-group">
-      <%= f.label :device_name %>
+      <%= f.label "デバイス名" %>
       <%= f.text_field :device_name, class: 'form-control' %>
     </div>
     <div class="form-group">
-      <%= f.label :mac_address %>
+      <%= f.label "macアドレス" %>
       <%= f.text_field :mac_address, class: 'form-control', pattern: "\d{1,2}\:\d{1,2}\:\d{1,2}\:\d{1,2}\:\d{1,2}\:\d{1,2}\:", placeholder: "xx:xx:xx:xx:xx:xx" %>
     </div>
     <div class="form-group">
       <%= f.label :preset_temperature, '設定温度' %>
-      <%= f.number_field :preset_temperature, class: 'form-control', placeholder: "20〜30の数字で入力すること"%>
+      <%= f.number_field :preset_temperature, class: 'form-control', min: 20, max: 30, placeholder: "20〜30の数字で入力すること" %>
     </div>
     <div class="form-group">
       <div class="control-label form-inline">
         <%= f.check_box :device_communication, {}, "true", "false" %>
-        <%= f.label :device_communication, 'デバイスとの接続スイッチをオン' %>
+        <%= f.label :device_communication, 'デバイスと接続する' %>
       </div>
     </div>
 

--- a/app/views/devices/new.html.erb
+++ b/app/views/devices/new.html.erb
@@ -2,21 +2,23 @@
 
 <div class="container">
   <%= form_for(@device) do |f| %>
+    <%= render 'shared/error_messages' %>
+
     <div class="form-group">
       <%= f.label :device_name %>
-      <%= f.text_field :device_name %>
+      <%= f.text_field :device_name, class: 'form-control' %>
     </div>
     <div class="form-group">
       <%= f.label :mac_address %>
-      <%= f.text_field :mac_address %>
+      <%= f.text_field :mac_address, class: 'form-control' %>
     </div>
     <div class="form-group">
       <%= f.label :preset_temperature, '設定温度（20〜30の数字で入力すること）' %>
-      <%= f.number_field :preset_temperature %>
+      <%= f.number_field :preset_temperature, class: 'form-control' %>
     </div>
     <div class="form-group">
       <%= f.label :device_communication, 'デバイスとの接続スイッチ のオン/オフ' %>
-      <%= f.text_field :device_communication %>
+      <%= f.text_field :device_communication, class: 'form-control' %>
     </div>
 
     <%= f.submit "Create new device", class: "btn btn-large btn-primary" %>

--- a/app/views/devices/new.html.erb
+++ b/app/views/devices/new.html.erb
@@ -14,7 +14,7 @@
     </div>
     <div class="form-group">
       <%= f.label :preset_temperature, '設定温度（20〜30の数字で入力すること）' %>
-      <%= f.number_field :preset_temperature, class: 'form-control' %>
+      <%= f.number_field :preset_temperature, class: 'form-control' %>度
     </div>
     <div class="form-group">
       <%= f.label :device_communication, 'デバイスとの接続スイッチ のオン/オフ' %>

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -4,8 +4,9 @@
   <table class="table">
   <thead>
     <tr>
-      <th>デバイス情報</th>
+      <th>デバイス名</th>
       <th>設定値</th>
+      <th>デバイスとの接続オン/オフ</th>
     </tr>
   </thead>
   <tbody>
@@ -15,6 +16,16 @@
       </td>
       <td>
         <%= @device.preset_temperature %>
+      </td>
+      <td>
+        <% if @device.device_communication %>
+          <%= "オン" %>
+        <% else %>
+          <%= "オフ" %>
+        <% end %>
+      </td>
+      <td>
+        <%= @device.mac_address %>
       </td>
     </tr>
   </tbody>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,11 +1,11 @@
 <% if @device.errors.any? %>
-<div id="error_explanation">
-  <div class="alert alert-danger">
+<div id="error_explanation" class="alert alert-danger">
+  <% if @device.errors.any? %>
   <ul>
-    <% @device.errors.messages.each do |msg| %>
-      <li><%= msg[1][1] %></li>
+    <% @device.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
     <% end %>
   </ul>
-  </div>
+  <% end %>
 </div>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -4,8 +4,8 @@
     入力した値が不正です<%= "#{@device.errors.count}件のエラー" %>
   </di>
   <ul>
-    <% @device.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+    <% @device.errors.messages.each do |msg| %>
+      <li><%= msg[1][1] %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @device.errors.any? %>
+<div id="error_explanation">
+  <di class="alert alert-danger">
+    入力した値が不正です<%= "#{@device.errors.count}件のエラー" %>
+  </di>
+  <ul>
+    <% @device.errors.messages.each do |msg| %>
+      <li><%= msg[1][1] %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,12 +1,11 @@
 <% if @device.errors.any? %>
 <div id="error_explanation">
-  <di class="alert alert-danger">
-    入力した値が不正です<%= "#{@device.errors.count}件のエラー" %>
-  </di>
+  <div class="alert alert-danger">
   <ul>
     <% @device.errors.messages.each do |msg| %>
       <li><%= msg[1][1] %></li>
     <% end %>
   </ul>
+  </div>
 </div>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @device.errors.any? %>
+<div id="error_explanation">
+  <di class="alert alert-danger">
+    入力した値が不正です<%= "#{@device.errors.count}件のエラー" %>
+  </di>
+  <ul>
+    <% @device.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get    'signup'     => 'top#signup'
   post   'login'   => 'top#check'
   delete 'logout'  => 'top#destroy'
-  get   'device'   => 'top#device'
+  # get   'device'   => 'top#device'
 
   resources :devices
 end

--- a/db/migrate/20161209031616_change_column_type_device_communication_to_devices.rb
+++ b/db/migrate/20161209031616_change_column_type_device_communication_to_devices.rb
@@ -1,0 +1,5 @@
+class ChangeColumnTypeDeviceCommunicationToDevices < ActiveRecord::Migration[5.0]
+  def change
+    change_column :devices, :device_communication, :boolean, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161204045341) do
+ActiveRecord::Schema.define(version: 20161209031616) do
 
   create_table "devices", force: :cascade do |t|
     t.string   "mac_address"
     t.integer  "preset_temperature"
     t.string   "device_name",          null: false
-    t.string   "device_communication"
+    t.boolean  "device_communication", null: false
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
   end


### PR DESCRIPTION
issue#15 デバイスの入力画面を作る => 入力時のエラーメッセージの表示
#やったこと
-deviceテーブルのdevice_communicationカラムをbooleanにした
-それに伴いviewのdevice_communicationをチェックボックスに変更した
-バリデーションエラーになった時にエラーメッセージを画面に表示した
-mac_addressと温度設定の項目で範囲外の入力に対してチップがでるようにした

#やりたかったけどできなかったこと
-フォームで未入力の項目についてエラーメッセージを出したが、日本語のエラーメッセージの前にテーブルのカラム名が表示され、それを消したかったがやりかたがわからなかった。
-flashメッセージをflash.nowにしたが画面をリロードしても消えない